### PR TITLE
Update statamic/cms version constraint to include ^6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^4.16 || ^5"
+        "statamic/cms": "^4.16 || ^5 || ^6"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.3",


### PR DESCRIPTION
Not sure if this is all that's required for v6, but I'd be happy to test this. 